### PR TITLE
Fix DNS issue

### DIFF
--- a/coredns.tf
+++ b/coredns.tf
@@ -3,6 +3,7 @@ resource "shell_script" "coredns-yaml" {
     create = <<-EOF
         mkdir -p coredns
         wget -q --https-only --timestamping "https://storage.googleapis.com/kubernetes-the-hard-way/coredns-1.8.yaml" -O coredns/coredns-1.8.yaml
+        sed -i "s%loadbalance%loadbalance\n\tforward . /etc/resolv%" coredns/coredns-1.8.yaml
     EOF
     read   = <<-EOF
         echo "{\"md5\": \"$(md5sum coredns/coredns-1.8.yaml|base64)\"}"

--- a/workers/playbook.yaml
+++ b/workers/playbook.yaml
@@ -13,3 +13,6 @@
     - name: Disable swap
       command: swapoff -a
       become: true
+    - name: Add modprobe support for DNS
+      command: modprobe br_netfilter
+      become: true


### PR DESCRIPTION
**Problems:**
1. No external request succeed 
```bash
kubectl apply -f https://k8s.io/examples/admin/dns/dnsutils.yaml
kubectl exec -i -t dnsutils -- nslookup google.fr
```
  I got SRVFAIL for google.fr.eu-west-2.compute.internal

2. Internal request failed
```bash
kubectl apply -f https://k8s.io/examples/admin/dns/dnsutils.yaml
kubectl exec -i -t dnsutils -- nslookup kubernetes
```
  I got "reply from unexpected source"

**Possible solution:**
- add br_netfilter module to egt rid of "reply from unexpected source"
(https://github.com/kubernetes/kubernetes/issues/21613#issuecomment-343190401)
- forward external request to the router DNS